### PR TITLE
Changing Links to Point Toward w241 datahub 

### DIFF
--- a/week_01/base_r.md
+++ b/week_01/base_r.md
@@ -1,17 +1,2 @@
-# Coding in Class
-Throughout the semester, we're going to insert breaks in the lecture action to get you involved programming. There are two types of activity we will ask you do to: (1) Coding Yoga; and, (2) Coding Workouts.
-
-1. **Yoga** is going to be *mellow*, highly guided sessions where we will be showing you things, in code, that we just been talking about in the async lectures. We want to get you thinking about the code structures that we're using, and this is the most effective way. 
-2. **Hikes** are less structured than *yoga*. In a *hike*  your work is going to be self-guided. We will be providing data & context, some boilerplate, and a target to shoot for, but just how you get there will be up to you.
-
-(I mean, you signed up for some Berkeley, right?) 
-
-Not all weeks will have a code *hike* in them, but when we do, there will be only one per week, and it will be the last activity for the week. We will always let you know which you're working on, so you can set your expectations for time (and coffee) appropriately.
-
-# The Berkeley DataHub 
-The first time that you start a datahub server, the server pulling is going to pull materials from a GitHub repository and do a little housecleaning. After the first time, it will only pull differences. This means that the server should start, in general, in 30 seconds or less.
-
-For *in async* code demonstrations, we're going to use the UC Berkeley datahub. This is a lightweight compute system with a jupyter server and Rstudio server. You've got general access to this compute using your @berkeley.edu credentials. Don't get distracted by the link right now: but, this jupyter hub is housed at [datahub.berkeley.edu](datahub.berkelely.edu). If you're interested, you can read more about this compute system [here](https://jupyterhub.readthedocs.io/en/stable/).
-
-# Do some guided Yoga! 
-Head [here](http://datahub.berkeley.edu/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2FUCB-MIDS%2Fw241&branch=master&urlpath=rstudio) and navigate to `week_01>base_r.Rmd` to work on an exercize.
+# Do a Longer Hike! 
+Head [here](http://datahub.berkeley.edu/hub/user-redirect/git-pull?repo=https://github.com/d-alex-hughes/w241&branch=master&urlpath=rstudio) and navigate to `week_01>base_r.Rmd` to work on an exercize.

--- a/week_01/base_r.md
+++ b/week_01/base_r.md
@@ -1,2 +1,0 @@
-# Do a Longer Hike! 
-Head [here](http://datahub.berkeley.edu/hub/user-redirect/git-pull?repo=https://github.com/d-alex-hughes/w241&branch=master&urlpath=rstudio) and navigate to `week_01>base_r.Rmd` to work on an exercize.

--- a/week_01/base_r.md
+++ b/week_01/base_r.md
@@ -14,4 +14,4 @@ The first time that you start a datahub server, the server pulling is going to p
 For *in async* code demonstrations, we're going to use the UC Berkeley datahub. This is a lightweight compute system with a jupyter server and Rstudio server. You've got general access to this compute using your @berkeley.edu credentials. Don't get distracted by the link right now: but, this jupyter hub is housed at [datahub.berkeley.edu](datahub.berkelely.edu). If you're interested, you can read more about this compute system [here](https://jupyterhub.readthedocs.io/en/stable/).
 
 # Do some guided Yoga! 
-Head [here](http://datahub.berkeley.edu/hub/user-redirect/git-pull?repo=https://github.com/d-alex-hughes/241_revisions&branch=master&urlpath=rstudio) and navigate to `week_01>base_r.Rmd` to work on an exercize.
+Head [here](http://datahub.berkeley.edu/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2FUCB-MIDS%2Fw241&branch=master&urlpath=rstudio) and navigate to `week_01>base_r.Rmd` to work on an exercize.

--- a/week_01/data_table_in_r.md
+++ b/week_01/data_table_in_r.md
@@ -1,2 +1,2 @@
 # Do a Longer Hike! 
-Head [here](http://datahub.berkeley.edu/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2FUCB-MIDS%2Fw241&branch=master&urlpath=rstudio) and navigate to `week_01>data_table_in_r.Rmd` to work on an exercize.
+Head [here](http://datahub.berkeley.edu/hub/user-redirect/git-pull?repo=https://github.com/d-alex-hughes/w241&branch=master&urlpath=rstudio) and navigate to `week_01>data_table_in_r.Rmd` to work on an exercize.

--- a/week_01/data_table_in_r.md
+++ b/week_01/data_table_in_r.md
@@ -1,2 +1,0 @@
-# Do a Longer Hike! 
-Head [here](http://datahub.berkeley.edu/hub/user-redirect/git-pull?repo=https://github.com/d-alex-hughes/w241&branch=master&urlpath=rstudio) and navigate to `week_01>data_table_in_r.Rmd` to work on an exercize.

--- a/week_01/data_table_in_r.md
+++ b/week_01/data_table_in_r.md
@@ -1,2 +1,2 @@
 # Do a Longer Hike! 
-Head [here](http://datahub.berkeley.edu/hub/user-redirect/git-pull?repo=https://github.com/d-alex-hughes/241_revisions&branch=master&urlpath=rstudio) and navigate to `week_01>data_table_in_r.Rmd` to work on an exercize.
+Head [here](http://datahub.berkeley.edu/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2FUCB-MIDS%2Fw241&branch=master&urlpath=rstudio) and navigate to `week_01>data_table_in_r.Rmd` to work on an exercize.

--- a/week_01/reintroduction_to_r.md
+++ b/week_01/reintroduction_to_r.md
@@ -1,2 +1,2 @@
 # Do Some Short Yoga! 
-Head [here](http://datahub.berkeley.edu/hub/user-redirect/git-pull?repo=https://github.com/d-alex-hughes/241_revisions&branch=master&urlpath=rstudio) and navigate to `week_01>reintroduction_to_r.Rmd` to work on an exercize.
+Head [here](http://datahub.berkeley.edu/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2FUCB-MIDS%2Fw241&branch=master&urlpath=rstudio) and navigate to `week_01>reintroduction_to_r.Rmd` to work on an exercize.

--- a/week_01/reintroduction_to_r.md
+++ b/week_01/reintroduction_to_r.md
@@ -1,2 +1,0 @@
-# Do Some Short Yoga! 
-Head [here](http://datahub.berkeley.edu/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2FUCB-MIDS%2Fw241&branch=master&urlpath=rstudio) and navigate to `week_01>reintroduction_to_r.Rmd` to work on an exercize.

--- a/week_02/demo-random_sampling.md
+++ b/week_02/demo-random_sampling.md
@@ -1,2 +1,2 @@
 # Do Some Short Yoga! 
-Head [here](http://datahub.berkeley.edu/hub/user-redirect/git-pull?repo=https://github.com/d-alex-hughes/241_revisions&branch=master&urlpath=rstudio) and navigate to `week_02>demo-random_sampling.Rmd` to work on an exercize.
+Head [here](http://datahub.berkeley.edu/hub/user-redirect/git-pull?repo=https://github.com/d-alex-hughes/w241&branch=master&urlpath=rstudio) and navigate to `week_02>demo-random_sampling.Rmd` to work on an exercize.

--- a/week_02/practice_with_r_and_data_table.md
+++ b/week_02/practice_with_r_and_data_table.md
@@ -1,2 +1,2 @@
 # Do a Longer Hike! 
-Head [here](http://datahub.berkeley.edu/hub/user-redirect/git-pull?repo=https://github.com/d-alex-hughes/241_revisions&branch=master&urlpath=rstudio) and navigate to `week_02>practice_with_r_and_data_table.Rmd` to work on an exercize.
+Head [here](http://datahub.berkeley.edu/hub/user-redirect/git-pull?repo=https://github.com/d-alex-hughes/w241&branch=master&urlpath=rstudio) and navigate to `week_02>practice_with_r_and_data_table.Rmd` to work on an exercize.

--- a/week_02/redux-potential_outcomes_as_theoretical_concepts.md
+++ b/week_02/redux-potential_outcomes_as_theoretical_concepts.md
@@ -1,2 +1,2 @@
 # Do Some Short Yoga! 
-Head [here](http://datahub.berkeley.edu/hub/user-redirect/git-pull?repo=https://github.com/d-alex-hughes/241_revisions&branch=master&urlpath=rstudio) and navigate to `week_02>redux-potential_outcomes_as_theoretical_concepts.Rmd` to work on an exercize.
+Head [here](http://datahub.berkeley.edu/hub/user-redirect/git-pull?repo=https://github.com/d-alex-hughes/w241&branch=master&urlpath=rstudio) and navigate to `week_02>redux-potential_outcomes_as_theoretical_concepts.Rmd` to work on an exercize.

--- a/week_03/apply_these_concepts.md
+++ b/week_03/apply_these_concepts.md
@@ -1,2 +1,2 @@
 # Do a Longer Hike! 
-Head [here](http://datahub.berkeley.edu/hub/user-redirect/git-pull?repo=https://github.com/d-alex-hughes/241_revisions&branch=master&urlpath=rstudio) and navigate to `week_03>apply_these_concepts.Rmd` to work on an exercize.
+Head [here](http://datahub.berkeley.edu/hub/user-redirect/git-pull?repo=https://github.com/d-alex-hughes/w241&branch=master&urlpath=rstudio) and navigate to `week_03>apply_these_concepts.Rmd` to work on an exercize.

--- a/week_03/applying_the_null_hypothesis.md
+++ b/week_03/applying_the_null_hypothesis.md
@@ -1,2 +1,2 @@
 # Do Some Short Yoga! 
-Head [here](http://datahub.berkeley.edu/hub/user-redirect/git-pull?repo=https://github.com/d-alex-hughes/241_revisions&branch=master&urlpath=rstudio) and navigate to `week_03>applying_the_null_hypothesis.Rmd` to work on an exercize.
+Head [here](http://datahub.berkeley.edu/hub/user-redirect/git-pull?repo=https://github.com/d-alex-hughes/w241&branch=master&urlpath=rstudio) and navigate to `week_03>applying_the_null_hypothesis.Rmd` to work on an exercize.

--- a/week_03/r_code_reference.md
+++ b/week_03/r_code_reference.md
@@ -1,2 +1,2 @@
 # Do Some Short Yoga! 
-Head [here](http://datahub.berkeley.edu/hub/user-redirect/git-pull?repo=https://github.com/d-alex-hughes/241_revisions&branch=master&urlpath=rstudio) and navigate to `week_03>r_code_reference.Rmd` to work on an exercize.
+Head [here](http://datahub.berkeley.edu/hub/user-redirect/git-pull?repo=https://github.com/d-alex-hughes/w241&branch=master&urlpath=rstudio) and navigate to `week_03>r_code_reference.Rmd` to work on an exercize.

--- a/week_03/talk_through_changes.md
+++ b/week_03/talk_through_changes.md
@@ -1,2 +1,2 @@
 # Do Some Short Yoga! 
-Head [here](http://datahub.berkeley.edu/hub/user-redirect/git-pull?repo=https://github.com/d-alex-hughes/241_revisions&branch=master&urlpath=rstudio) and navigate to `week_03>talk_through_changes.Rmd` to work on an exercize.
+Head [here](http://datahub.berkeley.edu/hub/user-redirect/git-pull?repo=https://github.com/d-alex-hughes/w241&branch=master&urlpath=rstudio) and navigate to `week_03>talk_through_changes.Rmd` to work on an exercize.

--- a/week_04/demo_of_robust_ses.md
+++ b/week_04/demo_of_robust_ses.md
@@ -1,2 +1,2 @@
 # Do Some Short Yoga! 
-Head [here](http://datahub.berkeley.edu/hub/user-redirect/git-pull?repo=https://github.com/d-alex-hughes/241_revisions&branch=master&urlpath=rstudio) and navigate to `week_04>demo_of_robust_ses.Rmd` to work on an exercize.
+Head [here](http://datahub.berkeley.edu/hub/user-redirect/git-pull?repo=https://github.com/d-alex-hughes/w241&branch=master&urlpath=rstudio) and navigate to `week_04>demo_of_robust_ses.Rmd` to work on an exercize.

--- a/week_04/r_code_reference.md
+++ b/week_04/r_code_reference.md
@@ -1,2 +1,2 @@
 # Do Some Short Yoga! 
-Head [here](http://datahub.berkeley.edu/hub/user-redirect/git-pull?repo=https://github.com/d-alex-hughes/241_revisions&branch=master&urlpath=rstudio) and navigate to `week_04>r_code_reference.Rmd` to work on an exercize.
+Head [here](http://datahub.berkeley.edu/hub/user-redirect/git-pull?repo=https://github.com/d-alex-hughes/w241&branch=master&urlpath=rstudio) and navigate to `week_04>r_code_reference.Rmd` to work on an exercize.

--- a/week_05/conduct_a_randomization_check.md
+++ b/week_05/conduct_a_randomization_check.md
@@ -1,2 +1,2 @@
 # Do a Longer Hike! 
-Head [here](http://datahub.berkeley.edu/hub/user-redirect/git-pull?repo=https://github.com/d-alex-hughes/241_revisions&branch=master&urlpath=rstudio) and navigate to `week_05>conduct_a_randomization_check.Rmd` to work on an exercize.
+Head [here](http://datahub.berkeley.edu/hub/user-redirect/git-pull?repo=https://github.com/d-alex-hughes/w241&branch=master&urlpath=rstudio) and navigate to `week_05>conduct_a_randomization_check.Rmd` to work on an exercize.

--- a/week_05/regression_analysis_notebook.md
+++ b/week_05/regression_analysis_notebook.md
@@ -1,2 +1,2 @@
 # Do a Longer Hike! 
-Head [here](http://datahub.berkeley.edu/hub/user-redirect/git-pull?repo=https://github.com/d-alex-hughes/241_revisions&branch=master&urlpath=rstudio) and navigate to `week_05>regression_analysis_notebook.Rmd` to work on an exercize.
+Head [here](http://datahub.berkeley.edu/hub/user-redirect/git-pull?repo=https://github.com/d-alex-hughes/w241&branch=master&urlpath=rstudio) and navigate to `week_05>regression_analysis_notebook.Rmd` to work on an exercize.

--- a/week_06/coding_bad_controls.md
+++ b/week_06/coding_bad_controls.md
@@ -1,2 +1,2 @@
 # Do Some Short Yoga! 
-Head [here](http://datahub.berkeley.edu/hub/user-redirect/git-pull?repo=https://github.com/d-alex-hughes/241_revisions&branch=master&urlpath=rstudio) and navigate to `week_06>coding_bad_controls.Rmd` to work on an exercize.
+Head [here](http://datahub.berkeley.edu/hub/user-redirect/git-pull?repo=https://github.com/d-alex-hughes/w241&branch=master&urlpath=rstudio) and navigate to `week_06>coding_bad_controls.Rmd` to work on an exercize.

--- a/week_06/demo-regression_analysis_of_multifactor_experiments.md
+++ b/week_06/demo-regression_analysis_of_multifactor_experiments.md
@@ -1,2 +1,2 @@
 # Do Some Short Yoga! 
-Head [here](http://datahub.berkeley.edu/hub/user-redirect/git-pull?repo=https://github.com/d-alex-hughes/241_revisions&branch=master&urlpath=rstudio) and navigate to `week_06>demo-regression_analysis_of_multifactor_experiments.Rmd` to work on an exercize.
+Head [here](http://datahub.berkeley.edu/hub/user-redirect/git-pull?repo=https://github.com/d-alex-hughes/w241&branch=master&urlpath=rstudio) and navigate to `week_06>demo-regression_analysis_of_multifactor_experiments.Rmd` to work on an exercize.

--- a/week_07/code_htes.md
+++ b/week_07/code_htes.md
@@ -1,2 +1,2 @@
 # Do a Longer Hike! 
-Head [here](http://datahub.berkeley.edu/hub/user-redirect/git-pull?repo=https://github.com/d-alex-hughes/241_revisions&branch=master&urlpath=rstudio) and navigate to `week_07>code_htes.Rmd` to work on an exercize.
+Head [here](http://datahub.berkeley.edu/hub/user-redirect/git-pull?repo=https://github.com/d-alex-hughes/w241&branch=master&urlpath=rstudio) and navigate to `week_07>code_htes.Rmd` to work on an exercize.

--- a/week_07/practice_exercise.md
+++ b/week_07/practice_exercise.md
@@ -1,2 +1,2 @@
 # Do a Longer Hike! 
-Head [here](http://datahub.berkeley.edu/hub/user-redirect/git-pull?repo=https://github.com/d-alex-hughes/241_revisions&branch=master&urlpath=rstudio) and navigate to `week_07>practice_exercise.Rmd` to work on an exercize.
+Head [here](http://datahub.berkeley.edu/hub/user-redirect/git-pull?repo=https://github.com/d-alex-hughes/w241&branch=master&urlpath=rstudio) and navigate to `week_07>practice_exercise.Rmd` to work on an exercize.

--- a/week_07/practice_exercise_-optional-.md
+++ b/week_07/practice_exercise_-optional-.md
@@ -1,2 +1,2 @@
 # Do a Longer Hike! 
-Head [here](http://datahub.berkeley.edu/hub/user-redirect/git-pull?repo=https://github.com/d-alex-hughes/241_revisions&branch=master&urlpath=rstudio) and navigate to `week_07>practice_exercise_-optional-.Rmd` to work on an exercize.
+Head [here](http://datahub.berkeley.edu/hub/user-redirect/git-pull?repo=https://github.com/d-alex-hughes/w241&branch=master&urlpath=rstudio) and navigate to `week_07>practice_exercise_-optional-.Rmd` to work on an exercize.

--- a/week_08/demonstration_of_itt_and_cace.md
+++ b/week_08/demonstration_of_itt_and_cace.md
@@ -1,2 +1,2 @@
 # Do Some Short Yoga! 
-Head [here](http://datahub.berkeley.edu/hub/user-redirect/git-pull?repo=https://github.com/d-alex-hughes/241_revisions&branch=master&urlpath=rstudio) and navigate to `week_08>demonstration_of_itt_and_cace.Rmd` to work on an exercize.
+Head [here](http://datahub.berkeley.edu/hub/user-redirect/git-pull?repo=https://github.com/d-alex-hughes/w241&branch=master&urlpath=rstudio) and navigate to `week_08>demonstration_of_itt_and_cace.Rmd` to work on an exercize.

--- a/week_08/practice.md
+++ b/week_08/practice.md
@@ -1,2 +1,2 @@
 # Do a Longer Hike! 
-Head [here](http://datahub.berkeley.edu/hub/user-redirect/git-pull?repo=https://github.com/d-alex-hughes/241_revisions&branch=master&urlpath=rstudio) and navigate to `week_08>practice.Rmd` to work on an exercize.
+Head [here](http://datahub.berkeley.edu/hub/user-redirect/git-pull?repo=https://github.com/d-alex-hughes/w241&branch=master&urlpath=rstudio) and navigate to `week_08>practice.Rmd` to work on an exercize.

--- a/week_09/estimating_in_the_presence_of_spillover.md
+++ b/week_09/estimating_in_the_presence_of_spillover.md
@@ -1,2 +1,2 @@
 # Do Some Short Yoga! 
-Head [here](http://datahub.berkeley.edu/hub/user-redirect/git-pull?repo=https://github.com/d-alex-hughes/241_revisions&branch=master&urlpath=rstudio) and navigate to `week_09>estimating_in_the_presence_of_spillover.Rmd` to work on an exercize.
+Head [here](http://datahub.berkeley.edu/hub/user-redirect/git-pull?repo=https://github.com/d-alex-hughes/w241&branch=master&urlpath=rstudio) and navigate to `week_09>estimating_in_the_presence_of_spillover.Rmd` to work on an exercize.

--- a/week_09/estimating_with_clustered_standard_errors.md
+++ b/week_09/estimating_with_clustered_standard_errors.md
@@ -1,2 +1,2 @@
 # Do Some Short Yoga! 
-Head [here](http://datahub.berkeley.edu/hub/user-redirect/git-pull?repo=https://github.com/d-alex-hughes/241_revisions&branch=master&urlpath=rstudio) and navigate to `week_09>estimating_with_clustered_standard_errors.Rmd` to work on an exercize.
+Head [here](http://datahub.berkeley.edu/hub/user-redirect/git-pull?repo=https://github.com/d-alex-hughes/w241&branch=master&urlpath=rstudio) and navigate to `week_09>estimating_with_clustered_standard_errors.Rmd` to work on an exercize.

--- a/week_09/unsuccessfully_estimating_in_the_presence_of_spillover.md
+++ b/week_09/unsuccessfully_estimating_in_the_presence_of_spillover.md
@@ -1,2 +1,2 @@
 # Do Some Short Yoga! 
-Head [here](http://datahub.berkeley.edu/hub/user-redirect/git-pull?repo=https://github.com/d-alex-hughes/241_revisions&branch=master&urlpath=rstudio) and navigate to `week_09>unsuccessfully_estimating_in_the_presence_of_spillover.Rmd` to work on an exercize.
+Head [here](http://datahub.berkeley.edu/hub/user-redirect/git-pull?repo=https://github.com/d-alex-hughes/w241&branch=master&urlpath=rstudio) and navigate to `week_09>unsuccessfully_estimating_in_the_presence_of_spillover.Rmd` to work on an exercize.

--- a/week_10/combining_or_separating.md
+++ b/week_10/combining_or_separating.md
@@ -1,2 +1,2 @@
 # Do Some Short Yoga! 
-Head [here](http://datahub.berkeley.edu/hub/user-redirect/git-pull?repo=https://github.com/d-alex-hughes/241_revisions&branch=master&urlpath=rstudio) and navigate to `week_10>combining_or_separating.Rmd` to work on an exercize.
+Head [here](http://datahub.berkeley.edu/hub/user-redirect/git-pull?repo=https://github.com/d-alex-hughes/w241&branch=master&urlpath=rstudio) and navigate to `week_10>combining_or_separating.Rmd` to work on an exercize.

--- a/week_10/detecting_errors.md
+++ b/week_10/detecting_errors.md
@@ -1,2 +1,2 @@
 # Do Some Short Yoga! 
-Head [here](http://datahub.berkeley.edu/hub/user-redirect/git-pull?repo=https://github.com/d-alex-hughes/241_revisions&branch=master&urlpath=rstudio) and navigate to `week_10>detecting_errors.Rmd` to work on an exercize.
+Head [here](http://datahub.berkeley.edu/hub/user-redirect/git-pull?repo=https://github.com/d-alex-hughes/w241&branch=master&urlpath=rstudio) and navigate to `week_10>detecting_errors.Rmd` to work on an exercize.

--- a/week_11/demo_of_regression_discontinuity.md
+++ b/week_11/demo_of_regression_discontinuity.md
@@ -1,2 +1,2 @@
 # Do Some Short Yoga! 
-Head [here](http://datahub.berkeley.edu/hub/user-redirect/git-pull?repo=https://github.com/d-alex-hughes/241_revisions&branch=master&urlpath=rstudio) and navigate to `week_11>demo_of_regression_discontinuity.Rmd` to work on an exercize.
+Head [here](http://datahub.berkeley.edu/hub/user-redirect/git-pull?repo=https://github.com/d-alex-hughes/w241&branch=master&urlpath=rstudio) and navigate to `week_11>demo_of_regression_discontinuity.Rmd` to work on an exercize.

--- a/week_11/two_stage_least_squares.md
+++ b/week_11/two_stage_least_squares.md
@@ -1,2 +1,2 @@
 # Do Some Short Yoga! 
-Head [here](http://datahub.berkeley.edu/hub/user-redirect/git-pull?repo=https://github.com/d-alex-hughes/241_revisions&branch=master&urlpath=rstudio) and navigate to `week_11>two_stage_least_squares.Rmd` to work on an exercize.
+Head [here](http://datahub.berkeley.edu/hub/user-redirect/git-pull?repo=https://github.com/d-alex-hughes/w241&branch=master&urlpath=rstudio) and navigate to `week_11>two_stage_least_squares.Rmd` to work on an exercize.

--- a/week_12/demo_of_attrition.md
+++ b/week_12/demo_of_attrition.md
@@ -1,2 +1,2 @@
 # Do Some Short Yoga! 
-Head [here](http://datahub.berkeley.edu/hub/user-redirect/git-pull?repo=https://github.com/d-alex-hughes/241_revisions&branch=master&urlpath=rstudio) and navigate to `week_12>demo_of_attrition.Rmd` to work on an exercize.
+Head [here](http://datahub.berkeley.edu/hub/user-redirect/git-pull?repo=https://github.com/d-alex-hughes/w241&branch=master&urlpath=rstudio) and navigate to `week_12>demo_of_attrition.Rmd` to work on an exercize.

--- a/week_12/estimating_with_attrition.md
+++ b/week_12/estimating_with_attrition.md
@@ -1,2 +1,2 @@
 # Do Some Short Yoga! 
-Head [here](http://datahub.berkeley.edu/hub/user-redirect/git-pull?repo=https://github.com/d-alex-hughes/241_revisions&branch=master&urlpath=rstudio) and navigate to `week_12>estimating_with_attrition.Rmd` to work on an exercize.
+Head [here](http://datahub.berkeley.edu/hub/user-redirect/git-pull?repo=https://github.com/d-alex-hughes/w241&branch=master&urlpath=rstudio) and navigate to `week_12>estimating_with_attrition.Rmd` to work on an exercize.

--- a/week_13/conduct_a_full_analysis.md
+++ b/week_13/conduct_a_full_analysis.md
@@ -1,2 +1,2 @@
 # Do a Longer Hike! 
-Head [here](http://datahub.berkeley.edu/hub/user-redirect/git-pull?repo=https://github.com/d-alex-hughes/241_revisions&branch=master&urlpath=rstudio) and navigate to `week_13>conduct_a_full_analysis.Rmd` to work on an exercize.
+Head [here](http://datahub.berkeley.edu/hub/user-redirect/git-pull?repo=https://github.com/d-alex-hughes/w241&branch=master&urlpath=rstudio) and navigate to `week_13>conduct_a_full_analysis.Rmd` to work on an exercize.


### PR DESCRIPTION
The previous version of these links was pointed toward the `w241_revisions` repo. That version is now dead, and has been fully incorporated into the core repo for the class -- `w241`. 

Pulling from the staging branch over to the master branch to put before students. 